### PR TITLE
添加了爱娇切者训练上手注目株的预处理

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -8,7 +8,7 @@ namespace UmamusumeDeserializeDB5
 {
     public static class UmamusumeDeserializeDB5
     {
-        public const string UmamusumeDatabaseFilePath = @"C:\Users\micro\AppData\LocalLow\Cygames\umamusume\master\master.mdb";
+        public const string UmamusumeDatabaseFilePath = @"C:\Users\Administrator\AppData\LocalLow\Cygames\umamusume\master\master.mdb";
         public static void Main()
         {
             Console.OutputEncoding = System.Text.Encoding.UTF8;

--- a/SuccessEvent.cs
+++ b/SuccessEvent.cs
@@ -56,28 +56,25 @@ namespace UmamusumeDeserializeDB5
             //爱娇、切者、练习上手、注目株
             for (int i = 0; i < stories.Count; i++)
             {
-                var Choices = new List<SuccessChoice>();
-                Choices.AddRange(stories[i].Choices.Where(x => (x.SuccessEffect.Contains("愛嬌◯") || x.SuccessEffect.Contains("切れ者") || x.SuccessEffect.Contains("練習上手◯") || x.SuccessEffect.Contains("注目株")) && !String.IsNullOrEmpty(x.FailedEffect) && x.FailedEffect != "-").Select(x => new SuccessChoice
+                var choices = stories[i].Choices
+                    .Where(x => (x.SuccessEffect.Contains("愛嬌◯") || x.SuccessEffect.Contains("切れ者") || x.SuccessEffect.Contains("練習上手◯") || x.SuccessEffect.Contains("注目株"))
+                && !string.IsNullOrEmpty(x.FailedEffect) && x.FailedEffect != "-").Select(x => new SuccessChoice
                 {
-                    ChoiceIndex=stories[i].Choices.IndexOf(x)+1,
-                    SelectIndex=2,
-                    Effects=new SuccessChoiceEffectDictionary
+                    ChoiceIndex = stories[i].Choices.IndexOf(x) + 1,
+                    SelectIndex = 2,
+                    Effects = new SuccessChoiceEffectDictionary
                     {
                         { 0, x.SuccessEffect }
                     }
-                }));
-                if (Choices.Count > 0)
+                });
+                if (!choices.Any() || successEvent.FirstOrDefault(x => x.Name == stories[i].Name) != default) continue;
+                successEvent.Add(new SuccessStory
                 {
-                    var dvent = new SuccessStory
-                    {
-                        Name = stories[i].Name,
-                        Choices = Choices
-                    };
-                    successEvent.Add(dvent);
-                }
+                    Name = stories[i].Name,
+                    Choices = choices.ToList()
+                });
             }
-
-            successEvent = successEvent.ToLookup(item => item.Name).ToDictionary(item => item.Key, item => item.First()).Values.ToList();
+            
             File.WriteAllText($"output/successevents.json", JsonConvert.SerializeObject(successEvent, Formatting.Indented));
         }
     }

--- a/SuccessEvent.cs
+++ b/SuccessEvent.cs
@@ -47,11 +47,11 @@ namespace UmamusumeDeserializeDB5
                      }
                  }
             }));
-            //爱娇、切者、练习上手
+            //爱娇、切者、练习上手、注目株
             for (int i = 0; i < stories.Count; i++)
             {
                 var Choices = new List<SuccessChoice>();
-                Choices.AddRange(stories[i].Choices.Where(x => (x.SuccessEffect.Contains("愛嬌◯") || x.SuccessEffect.Contains("切れ者") || x.SuccessEffect.Contains("練習上手◯")) && !String.IsNullOrEmpty(x.FailedEffect) && x.FailedEffect != "-").Select(x => new SuccessChoice
+                Choices.AddRange(stories[i].Choices.Where(x => (x.SuccessEffect.Contains("愛嬌◯") || x.SuccessEffect.Contains("切れ者") || x.SuccessEffect.Contains("練習上手◯") || x.SuccessEffect.Contains("注目株")) && !String.IsNullOrEmpty(x.FailedEffect) && x.FailedEffect != "-").Select(x => new SuccessChoice
                 {
                     ChoiceIndex=stories[i].Choices.IndexOf(x)+1,
                     SelectIndex=2,


### PR DESCRIPTION
添加了爱娇切者训练上手注目株的预处理，判断逻辑是存在FailedEffect且SelectId==2
保存json前检查本地是否已有数据，如果有的话就将新生成的拼接在后面并去重（理论上这样不会污染手动添加在前面的数据）
[successevents.txt](https://github.com/EtherealAO/UmamusumeDeserializeDB5/files/8632367/successevents.txt)
